### PR TITLE
MS To PLN : Pull PLN List

### DIFF
--- a/go/lib/ctrl/pln_mgmt/svccomm.go
+++ b/go/lib/ctrl/pln_mgmt/svccomm.go
@@ -1,0 +1,41 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pln_mgmt
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type PlnListReq struct {
+	Action string
+}
+
+func NewPlnListReq(action string) *PlnListReq {
+	return &PlnListReq{Action: action}
+}
+
+func (p *PlnListReq) ProtoId() proto.ProtoIdType {
+	return proto.PLN_TypeID
+}
+
+func (p *PlnListReq) Write(b common.RawBytes) (int, error) {
+	return proto.WriteRoot(p, b)
+}
+
+func (p *PlnListReq) String() string {
+	return fmt.Sprintf("%s ", p.Action)
+}

--- a/go/lib/ctrl/pln_mgmt/union.go
+++ b/go/lib/ctrl/pln_mgmt/union.go
@@ -20,8 +20,9 @@ import (
 
 // union represents the contents of the unnamed capnp union.
 type union struct {
-	Which   proto.PLN_Which
-	PlnList *PlnList `capnp:"plnList"`
+	Which      proto.PLN_Which
+	PlnList    *PlnList `capnp:"plnList"`
+	PlnListReq *PlnListReq
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -29,6 +30,9 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *PlnList:
 		u.Which = proto.PLN_Which_plnList
 		u.PlnList = p
+	case *PlnListReq:
+		u.Which = proto.PLN_Which_plnListReq
+		u.PlnListReq = p
 	default:
 		return common.NewBasicError("Unsupported PLN ctrl union type (set)", nil,
 			"type", common.TypeOf(c))
@@ -40,6 +44,8 @@ func (u *union) get() (proto.Cerealizable, error) {
 	switch u.Which {
 	case proto.PLN_Which_plnList:
 		return u.PlnList, nil
+	case proto.PLN_Which_plnListReq:
+		return u.PlnListReq, nil
 	}
 	return nil, common.NewBasicError("Unsupported PLN ctrl union type (get)", nil,
 		"type", u.Which)

--- a/go/lib/ctrl/union.go
+++ b/go/lib/ctrl/union.go
@@ -40,9 +40,9 @@ type union struct {
 	Sibra     []byte `capnp:"-"` // Omit for now
 	DRKeyMgmt []byte `capnp:"-"` // Omit for now
 	Sig       *sig_mgmt.Pld
+	Ms        *ms_mgmt.Pld
 	Pln       *pln_mgmt.Pld
 	Pgn       *pgn_mgmt.Pld
-	Ms        *ms_mgmt.Pld
 	Extn      *extn.CtrlExtnDataList
 	Ack       *ack.Ack
 }

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -153,6 +153,7 @@ const (
 	ASActionReply
 	MSFullMapRequest
 	MSFullMapReply
+	PlnListRequest
 )
 
 func (mt MessageType) String() string {
@@ -211,6 +212,8 @@ func (mt MessageType) String() string {
 		return "MSFullMapRequest"
 	case MSFullMapReply:
 		return "MSFullMapReply"
+	case PlnListRequest:
+		return "PlnListRequest"
 	default:
 		return fmt.Sprintf("Unknown (%d)", mt)
 	}
@@ -274,6 +277,8 @@ func (mt MessageType) MetricLabel() string {
 		return "ms_full_map_req"
 	case MSFullMapReply:
 		return "ms_full_map_push"
+	case PlnListRequest:
+		return "pln_list_req"
 	default:
 		return "unknown_mt"
 	}
@@ -365,7 +370,9 @@ type Messenger interface {
 		id uint64, messageType MessageType) error
 	GetFullMap(ctx context.Context, msg *ms_mgmt.Pld, a net.Addr,
 		id uint64) (*ctrl.SignedPld, error)
-  UpdateSigner(signer ctrl.Signer, types []MessageType)
+	GetPLNList(ctx context.Context, msg *pln_mgmt.Pld, a net.Addr,
+		id uint64) (*ctrl.SignedPld, error)
+	UpdateSigner(signer ctrl.Signer, types []MessageType)
 	UpdateVerifier(verifier Verifier)
 	AddHandler(msgType MessageType, h Handler)
 	ListenAndServe()
@@ -382,6 +389,7 @@ type ResponseWriter interface {
 	SendHPSegReply(ctx context.Context, msg *path_mgmt.HPSegReply) error
 	SendHPCfgReply(ctx context.Context, msg *path_mgmt.HPCfgReply) error
 	SendMSRep(ctx context.Context, msg *ms_mgmt.Pld, messageType MessageType) error
+	SendPLNList(ctx context.Context, msg *pln_mgmt.Pld) error
 }
 
 func ResponseWriterFromContext(ctx context.Context) (ResponseWriter, bool) {

--- a/go/lib/infra/messenger/quic_response_writer.go
+++ b/go/lib/infra/messenger/quic_response_writer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ms_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/pln_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/rpc"
 	"github.com/scionproto/scion/go/lib/log"
@@ -140,6 +141,19 @@ func (rw *QUICResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt
 
 func (rw *QUICResponseWriter) SendMSRep(ctx context.Context, msg *ms_mgmt.Pld,
 	messageType infra.MessageType) error {
+
+	go func() {
+		defer log.HandlePanic()
+		<-ctx.Done()
+		rw.ReplyWriter.Close()
+	}()
+	ctrlPld, err := ctrl.NewPld(msg, &ctrl.Data{ReqId: rw.ID, TraceId: tracing.IDFromCtx(ctx)})
+	if err != nil {
+		return err
+	}
+	return rw.sendMessage(ctx, ctrlPld)
+}
+func (rw *QUICResponseWriter) SendPLNList(ctx context.Context, msg *pln_mgmt.Pld) error {
 
 	go func() {
 		defer log.HandlePanic()

--- a/go/lib/infra/messenger/udp_response_writer.go
+++ b/go/lib/infra/messenger/udp_response_writer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ms_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/pln_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 )
 
@@ -73,4 +74,8 @@ func (rw *UDPResponseWriter) SendMSRep(ctx context.Context, msg *ms_mgmt.Pld,
 	messageType infra.MessageType) error {
 
 	return rw.Messenger.SendMSRep(ctx, msg, rw.Remote, rw.ID, messageType)
+}
+
+func (rw *UDPResponseWriter) SendPLNList(ctx context.Context, msg *pln_mgmt.Pld) error {
+	return rw.Messenger.SendPLNList(ctx, msg, rw.Remote, rw.ID)
 }

--- a/go/ms/internal/mscmn/common.go
+++ b/go/ms/internal/mscmn/common.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/ms/internal/mscrypto"
 	"github.com/scionproto/scion/go/ms/internal/msmsgr"
 	"github.com/scionproto/scion/go/ms/internal/validator"
+	"github.com/scionproto/scion/go/ms/plncomm"
 	"github.com/scionproto/scion/go/ms/sigcomm"
 	msconfig "github.com/scionproto/scion/go/pkg/ms/config"
 )
@@ -56,6 +57,7 @@ func Init(cfg msconfig.MsConf, sdCfg env.SCIONDClient, features env.Features) er
 		Router:                router,
 		SVCRouter:             messenger.NewSVCRouter(itopo.Provider()),
 		SVCResolutionFraction: 1, //this ensures that QUIC connection is always used
+		ConnectTimeout:        cfg.ConnectTimeout.Duration,
 	}
 	msmsgr.Msgr, err = nc.Messenger()
 	if err != nil {
@@ -65,6 +67,7 @@ func Init(cfg msconfig.MsConf, sdCfg env.SCIONDClient, features env.Features) er
 	mscrypto.CfgDir = cfg.CfgDir
 	validator.Path = cfg.RPKIValidator
 	validator.EntryValid = cfg.RPKIValidString
+	plncomm.PLNAddr = cfg.PLNIA
 
 	msmsgr.Msgr.AddHandler(infra.MSFullMapRequest, sigcomm.FullMapReqHandler{})
 	msmsgr.Msgr.AddHandler(infra.ASActionRequest, sigcomm.ASActionHandler{})

--- a/go/ms/plncomm/plncomm.go
+++ b/go/ms/plncomm/plncomm.go
@@ -1,0 +1,64 @@
+package plncomm
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/pln_mgmt"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/ms/internal/mscrypto"
+	"github.com/scionproto/scion/go/ms/internal/msmsgr"
+	"github.com/scionproto/scion/go/pkg/trust"
+	"github.com/scionproto/scion/go/pkg/trust/compat"
+)
+
+//PLNAddr address of the PLN that the MS is configured to connect to
+var PLNAddr addr.IA
+
+//PGN pgn objects that are returned from the PLN
+type PGN struct {
+	//PGNId is the id of the PGN In the IA it is deployed
+	PGNId string
+	//PGNIA ia of the PGN
+	PGNIA addr.IA
+}
+
+/*GetPLNList The Mapping Service sends the request using the infra.Messenger instance in msmsgr package and
+verifies the origin of the response before processing it. It then returns the processed list of
+PGN Id and IA objects to the calling function
+*/
+func GetPLNList(ctx context.Context) ([]PGN, error) {
+	address := &snet.SVCAddr{IA: PLNAddr, SVC: addr.SvcPLN}
+
+	plnListReq := pln_mgmt.NewPlnListReq("request")
+	pld, err := pln_mgmt.NewPld(1, plnListReq)
+	if err != nil {
+		return nil, serrors.WrapStr("Error creating pln_mgmt pld", err)
+	}
+
+	signedPld, err := msmsgr.Msgr.GetPLNList(ctx, pld, address, rand.Uint64())
+	if err != nil {
+		return nil, serrors.WrapStr("Error getting plnList from messenger", err)
+	}
+	e := mscrypto.MSEngine{Msgr: msmsgr.Msgr, IA: msmsgr.IA}
+	verifier := trust.Verifier{BoundIA: PLNAddr, Engine: e}
+
+	verifiedPayload, err := signedPld.GetVerifiedPld(context.Background(),
+		compat.Verifier{Verifier: verifier})
+
+	if err != nil {
+		return nil, serrors.WrapStr("Error getting verified payload", err)
+	}
+	plnList := verifiedPayload.Pln.PlnList
+
+	pgns := []PGN{}
+	for _, plnListEntry := range plnList.L {
+		pgn := PGN{PGNId: plnListEntry.PGNId, PGNIA: addr.IAInt(plnListEntry.IA).IA()}
+		pgns = append(pgns, pgn)
+	}
+	//Signature from PLN is validated, the list is now authenticated.
+
+	return pgns, nil
+}

--- a/go/ms/plncomm/plncomm.go
+++ b/go/ms/plncomm/plncomm.go
@@ -1,3 +1,17 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package plncomm
 
 import (

--- a/go/ms/plncomm/plncomm.go
+++ b/go/ms/plncomm/plncomm.go
@@ -39,9 +39,9 @@ type PGN struct {
 	PGNIA addr.IA
 }
 
-/*GetPLNList The Mapping Service sends the request using the infra.Messenger instance in msmsgr package and
-verifies the origin of the response before processing it. It then returns the processed list of
-PGN Id and IA objects to the calling function
+/*GetPLNList The Mapping Service sends the request using the infra.Messenger instance in msmsgr
+package and verifies the origin of the response before processing it. It then returns the processed
+list of PGN Id and IA objects to the calling function
 */
 func GetPLNList(ctx context.Context) ([]PGN, error) {
 	address := &snet.SVCAddr{IA: PLNAddr, SVC: addr.SvcPLN}

--- a/go/pkg/ms/config/configtest/configtest.go
+++ b/go/pkg/ms/config/configtest/configtest.go
@@ -36,6 +36,8 @@ func CheckTestMS(t *testing.T, cfg *config.MsConf, id string) {
 	assert.Equal(t, "validator.sh", cfg.RPKIValidator)
 	assert.Equal(t, "valid", cfg.RPKIValidString)
 	assert.Equal(t, xtest.MustParseIA("1-ff00:0:110"), cfg.PLNIA)
-	assert.Equal(t, config.DefaultMSListValidTime, int(cfg.MSListValidTime))
-	assert.Equal(t, config.DefaultMSPullListInterval, int(cfg.MSPullListInterval))
+	assert.Equal(t, config.DefaultMSListValidTime.Duration, cfg.MSListValidTime.Duration)
+	assert.Equal(t, config.DefaultMSPullListInterval.Duration, cfg.MSPullListInterval.Duration)
+	assert.Equal(t, config.DefaultConnectTimeout.Duration, cfg.ConnectTimeout.Duration)
+
 }

--- a/go/pkg/ms/config/sample.go
+++ b/go/pkg/ms/config/sample.go
@@ -53,9 +53,13 @@ rpki_entry_valid = "valid"
 #PLNIA IA of the PLN to contact for PCN lists (required)
 pln_isd_as = "1-ff00:0:110"
 
-#MSListValidTime time for which a published MS list is valid in minutes (default = 10080) 1 week
-ms_list_valid_time = 10080
+#MSListValidTime time for which a published MS list is valid in minutes (default = 168h) 1 week
+ms_list_valid_time = "168h"
 
-#MSPullListInterval time interval to pull full MS list in minutes (default = 1440) 1 day
-ms_pull_list_interval = 1440
+#MSPullListInterval time interval to pull full MS list in minutes (default = 24h) 1 day
+ms_pull_list_interval = "24h"
+
+#ConnectTimeout is the amount of time the messenger waits for a reply
+#from the other service that it connects to. default (1 minute)
+connect_timeout = "1m"
 `

--- a/go/pln/internal/plncmn/common.go
+++ b/go/pln/internal/plncmn/common.go
@@ -62,6 +62,7 @@ func Init(cfg plnconfig.PLNConf, sdCfg env.SCIONDClient, features env.Features) 
 
 	plnmsgr.Msgr.AddHandler(infra.AddPLNEntryRequest, pgncomm.AddPLNEntryHandler{})
 	plnmsgr.Msgr.AddHandler(infra.PlnListReply, plncomm.PLNListHandler{})
+	plnmsgr.Msgr.AddHandler(infra.PlnListRequest, svccomm.PlnListHandler{})
 
 	return nil
 }

--- a/go/pln/srvcomm/plnmshandlers.go
+++ b/go/pln/srvcomm/plnmshandlers.go
@@ -1,0 +1,74 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svccomm
+
+import (
+	"context"
+
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/pkg/trust"
+	"github.com/scionproto/scion/go/pln/internal/plncrypto"
+	"github.com/scionproto/scion/go/pln/internal/plnmsgr"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type SvcListHandler struct {
+}
+
+func (a SvcListHandler) Handle(r *infra.Request) *infra.HandlerResult {
+	log.Info("Entering: SvcListHandler.Handle")
+	ctx := r.Context()
+	rw, _ := infra.ResponseWriterFromContext(ctx)
+	sendAck := messenger.SendAckHelper(ctx, rw)
+
+	signer, err := registerSigner(infra.PlnListReply)
+	if err != nil {
+		log.Error("Error registering signer")
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+		return nil
+	}
+
+	switch t := rw.(type) {
+	case *messenger.QUICResponseWriter:
+		t.Signer = *signer
+	}
+
+	pld, err := plnmsgr.GetPLNListAsPld(r.ID)
+	if err != nil {
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+	}
+
+	err = rw.SendPLNList(context.Background(), pld)
+
+	if err != nil {
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+	}
+	return nil
+
+}
+
+func registerSigner(msgType infra.MessageType) (*trust.Signer, error) {
+	plncrypt := &plncrypto.PLNSigner{}
+	plncrypt.Init(context.Background(), plnmsgr.Msgr, plnmsgr.IA, plncrypto.CfgDir)
+	signer, err := plncrypt.SignerGen.Generate(context.Background())
+	if err != nil {
+		return nil, serrors.WrapStr("Unable to create signer", err)
+	}
+	plnmsgr.Msgr.UpdateSigner(signer, []infra.MessageType{msgType})
+	return &signer, nil
+}

--- a/go/pln/srvcomm/plnsvchandlers.go
+++ b/go/pln/srvcomm/plnsvchandlers.go
@@ -1,0 +1,75 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package svccomm
+
+import (
+	"context"
+
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/pkg/trust"
+	"github.com/scionproto/scion/go/pln/internal/plncrypto"
+	"github.com/scionproto/scion/go/pln/internal/plnmsgr"
+	"github.com/scionproto/scion/go/proto"
+)
+
+//SvcListHandler is the Handler to handle PLNList requests from services
+type SvcListHandler struct {
+}
+
+func (a SvcListHandler) Handle(r *infra.Request) *infra.HandlerResult {
+	log.Info("Entering: SvcListHandler.Handle")
+	ctx := r.Context()
+	rw, _ := infra.ResponseWriterFromContext(ctx)
+	sendAck := messenger.SendAckHelper(ctx, rw)
+
+	signer, err := registerSigner(infra.PlnListReply)
+	if err != nil {
+		log.Error("Error registering signer")
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+		return nil
+	}
+
+	switch t := rw.(type) {
+	case *messenger.QUICResponseWriter:
+		t.Signer = *signer
+	}
+
+	pld, err := plnmsgr.GetPLNListAsPld(r.ID)
+	if err != nil {
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+	}
+
+	err = rw.SendPLNList(context.Background(), pld)
+
+	if err != nil {
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+	}
+	return nil
+
+}
+
+func registerSigner(msgType infra.MessageType) (*trust.Signer, error) {
+	plncrypt := &plncrypto.PLNSigner{}
+	plncrypt.Init(context.Background(), plnmsgr.Msgr, plnmsgr.IA, plncrypto.CfgDir)
+	signer, err := plncrypt.SignerGen.Generate(context.Background())
+	if err != nil {
+		return nil, serrors.WrapStr("Unable to create signer", err)
+	}
+	plnmsgr.Msgr.UpdateSigner(signer, []infra.MessageType{msgType})
+	return &signer, nil
+}

--- a/go/sig/internal/mscomm/mscomm.go
+++ b/go/sig/internal/mscomm/mscomm.go
@@ -59,8 +59,8 @@ func AddASMap(ctx context.Context, ip string) error {
 				//Or the MS is down. Try again with a different core AS
 				log.Error("Not able to connect to MS", "IA ", ia.String())
 			} else {
-				//If the error is something other than not being able to reach a MS. Break and report
-				//that the sending failed. This will be retried in the next time interval
+				//If the error is something other than not being able to reach a MS. Break and
+				//report that the sending failed. This will be retried in the next time interval
 				return serrors.WrapStr("Error sending AS Action", err)
 			}
 		} else {
@@ -72,7 +72,7 @@ func AddASMap(ctx context.Context, ip string) error {
 		return doSuccess(rep, ia, ip)
 	}
 
-	return serrors.WrapStr("Pushing to MS was unsuccessfull",
+	return serrors.WrapStr("Pushing to MS was unsuccessful",
 		errors.New(`Could not connect to any MS in the core ASes. This could be because of 
 		very small configured connect_period or no MS instance deployed in any core AS`))
 }

--- a/proto/pln.capnp
+++ b/proto/pln.capnp
@@ -8,6 +8,7 @@ struct PLN {
     union {
         unset @1 :Void;
         plnList @2 :PlnList;
+        plnListReq @3 :PlnListReq;
     }
 }
 
@@ -21,3 +22,6 @@ struct PlnListEntry{
     raw @2 :Data;
 }
 
+struct PlnListReq{
+    action @0 :Text;
+}


### PR DESCRIPTION
This PR enables the MS to Pull PLN lists from PLNs
It contains the following changes:
- new message type to request PLN List 
- new config fields for MS 
- changes to MS to request PLN List
- changes to PLN to handle requests from MS

This PR does not have code to call plncomm.GetPLNList() in the MS. The function sends the request to the PLN and parses the response. It will be used in a subsequent PR.