### PR TITLE
PGN Gossip

### DIFF
--- a/go/cs/segreq/authoritative.go
+++ b/go/cs/segreq/authoritative.go
@@ -81,9 +81,9 @@ func (h *authoritativeProcessor) classify(ctx context.Context,
 	case src != h.localIA:
 		return proto.PathSegType_unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,
 			"src", src, "dst", dst, "reason", "src must be local AS")
-	case dst.I == 0:
-		return proto.PathSegType_unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,
-			"src", src, "dst", dst, "reason", "zero ISD dst")
+	// case dst.I == 0:
+	// 	return proto.PathSegType_unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,
+	// 		"src", src, "dst", dst, "reason", "zero ISD dst"
 	case dst.I == h.localIA.I:
 		dstCore, err := h.coreChecker.IsCore(ctx, dst)
 		if err != nil {

--- a/go/cs/segreq/forwarder.go
+++ b/go/cs/segreq/forwarder.go
@@ -82,10 +82,10 @@ func (h *forwarder) process(ctx context.Context,
 // classify validates the request and determines the segment type for the request
 func (h *forwarder) classify(ctx context.Context, src, dst addr.IA) (proto.PathSegType, error) {
 	unset := proto.PathSegType_unset // shorthand
-	if src.I == 0 || dst.I == 0 {
-		return unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,
-			"src", src, "dst", dst, "reason", "zero ISD src or dst")
-	}
+	// if src.I == 0 || dst.I == 0 {
+	// 	return unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,
+	// 		"src", src, "dst", dst, "reason", "zero ISD src or dst")
+	// }
 	if dst == h.localIA {
 		// this could be an otherwise valid request, but probably the requester switched Src and Dst
 		return unset, serrors.WithCtx(segfetcher.ErrInvalidRequest,

--- a/go/lib/ctrl/ms_mgmt/pgncomm.go
+++ b/go/lib/ctrl/ms_mgmt/pgncomm.go
@@ -1,0 +1,49 @@
+package ms_mgmt
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type SignedASEntry struct {
+	Blob common.RawBytes
+	Sign *proto.SignS
+}
+
+func NewSignedASEntry(blob common.RawBytes, sign *proto.SignS) *SignedASEntry {
+	return &SignedASEntry{Blob: blob, Sign: sign}
+}
+
+func (p *SignedASEntry) ProtoId() proto.ProtoIdType {
+	return proto.MS_TypeID
+}
+
+func (p *SignedASEntry) String() string {
+	return fmt.Sprintf("SignedASEntry: %s %s", p.Blob, p.Sign)
+}
+
+type SignedMSList struct {
+	Timestamp uint64
+	ASEntries []SignedASEntry `capnp:"asEntries"`
+	MSIA      string          `capnp:"msIA"`
+}
+
+func NewSignedMSList(timestamp uint64, asEntry []SignedASEntry,
+	msIA string) *SignedMSList {
+
+	return &SignedMSList{Timestamp: timestamp, ASEntries: asEntry, MSIA: msIA}
+}
+
+func (p *SignedMSList) ProtoId() proto.ProtoIdType {
+	return proto.SignedMSList_TypeID
+}
+
+func (p *SignedMSList) String() string {
+	s := ""
+	for _, asEntry := range p.ASEntries {
+		s = s + asEntry.String()
+	}
+	return fmt.Sprintf("%d %s %s", p.Timestamp, s, p.MSIA)
+}

--- a/go/lib/ctrl/ms_mgmt/pgncomm.go
+++ b/go/lib/ctrl/ms_mgmt/pgncomm.go
@@ -1,3 +1,17 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ms_mgmt
 
 import (

--- a/go/lib/ctrl/ms_mgmt/union.go
+++ b/go/lib/ctrl/ms_mgmt/union.go
@@ -7,11 +7,12 @@ import (
 
 // union represents the contents of the unnamed capnp union.
 type union struct {
-	Which       proto.MS_Which
-	AsActionReq *ASMapEntry
-	AsActionRep *MSRepToken
-	FullMapReq  *FullMapReq
-	FullMapRep  *FullMapRep
+	Which        proto.MS_Which
+	AsActionReq  *ASMapEntry
+	AsActionRep  *MSRepToken
+	FullMapReq   *FullMapReq
+	FullMapRep   *FullMapRep
+	SignedMSList *SignedMSList
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -28,6 +29,9 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *FullMapRep:
 		u.Which = proto.MS_Which_fullMapRep
 		u.FullMapRep = p
+	case *SignedMSList:
+		u.Which = proto.MS_Which_signedMSList
+		u.SignedMSList = p
 	default:
 		return common.NewBasicError("Unsupported MS ctrl union type (set)", nil,
 			"type", common.TypeOf(c))
@@ -45,6 +49,8 @@ func (u *union) get() (proto.Cerealizable, error) {
 		return u.FullMapReq, nil
 	case proto.MS_Which_fullMapRep:
 		return u.FullMapRep, nil
+	case proto.MS_Which_signedMSList:
+		return u.SignedMSList, nil
 	}
 	return nil, common.NewBasicError("Unsupported MS ctrl union type (get)", nil,
 		"type", u.Which)

--- a/go/lib/ctrl/pgn_mgmt/pgncomm.go
+++ b/go/lib/ctrl/pgn_mgmt/pgncomm.go
@@ -1,0 +1,31 @@
+package pgn_mgmt
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type PGNList struct {
+	//L should be a list of SignedPlds in bytes form.
+	L         []common.RawBytes
+	Timestamp uint64
+}
+
+func NewPGNList(l []common.RawBytes, timestamp uint64) *PGNList {
+	return &PGNList{L: l, Timestamp: timestamp}
+}
+
+func (p *PGNList) ProtoId() proto.ProtoIdType {
+	return proto.PGN_TypeID
+}
+
+func (p *PGNList) Write(b common.RawBytes) (int, error) {
+	return proto.WriteRoot(p, b)
+}
+
+func (p *PGNList) String() string {
+	str := ""
+	return fmt.Sprintf("%s %d", str, p.Timestamp)
+}

--- a/go/lib/ctrl/pgn_mgmt/pgncomm.go
+++ b/go/lib/ctrl/pgn_mgmt/pgncomm.go
@@ -1,3 +1,17 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pgn_mgmt
 
 import (

--- a/go/lib/ctrl/pgn_mgmt/svccomm.go
+++ b/go/lib/ctrl/pgn_mgmt/svccomm.go
@@ -21,12 +21,12 @@ import (
 )
 
 type AddPGNEntryRequest struct {
-	Entry     []byte
-	EntryType string
-	CommitID  string
-	PGNId     string `capnp:"pgnId"`
-	Timestamp uint64
-	SrcIA     string `capnp:"srcIA"`
+	Entry      []byte
+	EntryType  string
+	CommitID   string
+	PGNId      string `capnp:"pgnId"`
+	Timestamp  uint64
+	SrcIA      string `capnp:"srcIA"`
 }
 
 func NewAddPGNEntryRequest(entry []byte, entryType string, commitID string,

--- a/go/lib/ctrl/pgn_mgmt/union.go
+++ b/go/lib/ctrl/pgn_mgmt/union.go
@@ -23,7 +23,8 @@ type union struct {
 	Which              proto.PGN_Which
 	AddPLNEntryRequest *AddPLNEntryRequest
 	AddPGNEntryRequest *AddPGNEntryRequest
-	PGNRep             *PGNRep `capnp:"pgnRep"`
+	PGNRep             *PGNRep  `capnp:"pgnRep"`
+	PGNList            *PGNList `capnp:"pgnList"`
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -37,6 +38,9 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *PGNRep:
 		u.Which = proto.PGN_Which_pgnRep
 		u.PGNRep = p
+	case *PGNList:
+		u.Which = proto.PGN_Which_pgnList
+		u.PGNList = p
 	default:
 		return common.NewBasicError("Unsupported PGN ctrl union type (set)", nil,
 			"type", common.TypeOf(c))
@@ -52,6 +56,8 @@ func (u *union) get() (proto.Cerealizable, error) {
 		return u.AddPGNEntryRequest, nil
 	case proto.PGN_Which_pgnRep:
 		return u.PGNRep, nil
+	case proto.PGN_Which_pgnList:
+		return u.PGNList, nil
 	}
 	return nil, common.NewBasicError("Unsupported PLN ctrl union type (get)", nil,
 		"type", u.Which)

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -156,6 +156,7 @@ const (
 	PlnListRequest
 	AddPGNEntryRequest
 	PGNRep
+	PGNList
 )
 
 func (mt MessageType) String() string {
@@ -220,6 +221,8 @@ func (mt MessageType) String() string {
 		return "AddPGNEntryRequest"
 	case PGNRep:
 		return "PGNRep"
+	case PGNList:
+		return "PGNList"
 	default:
 		return fmt.Sprintf("Unknown (%d)", mt)
 	}
@@ -289,6 +292,8 @@ func (mt MessageType) MetricLabel() string {
 		return "add_pgn_entry_req"
 	case PGNRep:
 		return "pgn_rep"
+	case PGNList:
+		return "pgn_list"
 	default:
 		return "unknown_mt"
 	}

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -1260,6 +1260,8 @@ func Validate(pld *ctrl.Pld) (infra.MessageType, proto.Cerealizable, error) {
 			return infra.AddPGNEntryRequest, pld.Pgn.AddPGNEntryRequest, nil
 		case proto.PGN_Which_pgnRep:
 			return infra.PGNRep, pld.Pgn.PGNRep, nil
+		case proto.PGN_Which_pgnList:
+			return infra.PGNList, pld.Pgn.PGNList, nil
 		default:
 			return infra.None, nil,
 				common.NewBasicError("Unsupported SignedPld.CtrlPld.Pgn.Xxx message type",

--- a/go/lib/infra/modules/segfetcher/pather.go
+++ b/go/lib/infra/modules/segfetcher/pather.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/combinator"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/revcache"
-	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
 )
@@ -52,9 +51,9 @@ type Pather struct {
 func (p *Pather) GetPaths(ctx context.Context, dst addr.IA,
 	refresh bool) ([]*combinator.Path, error) {
 
-	if dst.I == 0 {
-		return nil, serrors.WithCtx(ErrBadDst, "dst", dst)
-	}
+	// if dst.I == 0 {
+	// 	return nil, serrors.WithCtx(ErrBadDst, "dst", dst)
+	// }
 	src := p.TopoProvider.Get().IA()
 	if dst.Equal(src) {
 		// For AS local communication, an empty path is used.

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -465,28 +465,54 @@ func (e *executor) buildQuery(params *query.Params) (string, []interface{}) {
 	if len(params.StartsAt) > 0 {
 		subQ := []string{}
 		for _, as := range params.StartsAt {
-			if as.A == 0 {
-				subQ = append(subQ, "(s.StartIsdID=?)")
-				args = append(args, as.I)
-			} else {
+			// if as.A == 0 {
+			// 	subQ = append(subQ, "(s.StartIsdID=?)")
+			// 	args = append(args, as.I)
+			// } else {
+			// 	subQ = append(subQ, "(s.StartIsdID=? AND s.StartAsID=?)")
+			// 	args = append(args, as.I, as.A)
+			// }
+			if as.I != 0 && as.A != 0 {
 				subQ = append(subQ, "(s.StartIsdID=? AND s.StartAsID=?)")
 				args = append(args, as.I, as.A)
+			} else if as.I != 0 {
+				subQ = append(subQ, "(s.StartIsdID=?)")
+				args = append(args, as.I)
+			} else if as.A != 0 {
+				subQ = append(subQ, "(s.StartAsID=?)")
+				args = append(args, as.A)
 			}
 		}
-		where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		//where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		if len(subQ) > 0 {
+			where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		}
 	}
 	if len(params.EndsAt) > 0 {
 		subQ := []string{}
 		for _, as := range params.EndsAt {
-			if as.A == 0 {
-				subQ = append(subQ, "(s.EndIsdID=?)")
-				args = append(args, as.I)
-			} else {
+			// if as.A == 0 {
+			// 	subQ = append(subQ, "(s.EndIsdID=?)")
+			// 	args = append(args, as.I)
+			// } else {
+			// 	subQ = append(subQ, "(s.EndIsdID=? AND s.EndAsID=?)")
+			// 	args = append(args, as.I, as.A)
+			// }
+			if as.I != 0 && as.A != 0 {
 				subQ = append(subQ, "(s.EndIsdID=? AND s.EndAsID=?)")
 				args = append(args, as.I, as.A)
+			} else if as.I != 0 {
+				subQ = append(subQ, "(s.EndIsdID=?)")
+				args = append(args, as.I)
+			} else if as.A != 0 {
+				subQ = append(subQ, "(s.EndAsID=?)")
+				args = append(args, as.A)
 			}
 		}
-		where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		//where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		if len(subQ) > 0 {
+			where = append(where, fmt.Sprintf("(%s)", strings.Join(subQ, " OR ")))
+		}
 	}
 	if params.MinLastUpdate != nil {
 		where = append(where, "(s.LastUpdated>?)")

--- a/go/pgn/internal/pgncmn/common.go
+++ b/go/pgn/internal/pgncmn/common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scionproto/scion/go/pgn/internal/pgnentryhelper"
 	"github.com/scionproto/scion/go/pgn/internal/pgnmsgr"
 	"github.com/scionproto/scion/go/pgn/mscomm"
+	"github.com/scionproto/scion/go/pgn/pgncomm"
 	pgnconfig "github.com/scionproto/scion/go/pkg/pgn/config"
 )
 
@@ -67,6 +68,7 @@ func Init(cfg pgnconfig.PGNConf, sdCfg env.SCIONDClient, features env.Features) 
 	pgnmsgr.IA = cfg.IA
 	pgncrypto.CfgDir = cfg.CfgDir
 	pgnmsgr.Msgr.AddHandler(infra.AddPGNEntryRequest, mscomm.AddPGNEntryReqHandler{})
+	pgnmsgr.Msgr.AddHandler(infra.PGNList, pgncomm.PGNEntryHandler{})
 
 	return nil
 }

--- a/go/pgn/internal/sqlite/updates.go
+++ b/go/pgn/internal/sqlite/updates.go
@@ -22,7 +22,7 @@ const (
 	entry = ?,
 	commitId = ?,
 	timestamp = ?,
-	signedBlob = ?,
+	signedBlob = ?
 	WHERE srcIA = ? and entryType = ?
 	`
 )

--- a/go/pgn/main.go
+++ b/go/pgn/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/scionproto/scion/go/pgn/internal/pgncmn"
 	"github.com/scionproto/scion/go/pgn/internal/pgnmsgr"
 	"github.com/scionproto/scion/go/pgn/internal/sqlite"
+	"github.com/scionproto/scion/go/pgn/pgncomm"
 	"github.com/scionproto/scion/go/pgn/plncomm"
 	pgnconfig "github.com/scionproto/scion/go/pkg/pgn/config"
 	"github.com/scionproto/scion/go/pkg/service"
@@ -112,6 +113,12 @@ func realMain() int {
 			return
 		}
 	}(context.Background(), cfg.General.ID, pgncmn.IA, pgncmn.PLNIA)
+
+	go func(ctx context.Context, plnIA addr.IA) {
+		defer log.HandlePanic()
+		pgncomm.N = int(cfg.PGN.NumPGNs)
+		pgncomm.BroadcastNodeList(ctx, cfg.PGN.PropagateInterval.Duration, plnIA)
+	}(context.Background(), cfg.PGN.PLNIA)
 
 	// Start HTTP endpoints.
 	statusPages := service.StatusPages{

--- a/go/pgn/pgncomm/pgncomm.go
+++ b/go/pgn/pgncomm/pgncomm.go
@@ -1,0 +1,125 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgncomm
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/pgn_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/pgn/internal/pgncrypto"
+	"github.com/scionproto/scion/go/pgn/internal/pgnmsgr"
+	"github.com/scionproto/scion/go/pgn/internal/sqlite"
+	"github.com/scionproto/scion/go/pgn/plncomm"
+)
+
+//N is the number of PGNs the list is propagated to in every time interval
+var N int
+
+func BroadcastNodeList(ctx context.Context, interval time.Duration, plnIA addr.IA) {
+	log.Info("Entering: BroadcastNodeList")
+	err := sendPGNList(ctx, plnIA)
+	if err != nil {
+		log.Error("error in broadcast node list", err)
+	}
+	pushTicker := time.NewTicker(interval * time.Second)
+	for {
+		select {
+		case <-pushTicker.C:
+			err = sendPGNList(ctx, plnIA)
+			if err != nil {
+				log.Error("error in broadcast node list", err)
+			}
+		}
+	}
+}
+
+func sendPGNList(ctx context.Context, plnIA addr.IA) error {
+	log.Info("Entering: sendPGNList")
+	dbEntries, err := sqlite.Db.GetAllEntries(context.Background())
+	if err != nil {
+		return serrors.WrapStr("Error getting full node list", err)
+	}
+
+	if len(dbEntries) > 0 {
+		pgns, err := plncomm.GetPLNList(ctx, plnIA)
+		if err != nil {
+			return serrors.WrapStr("Error getting pln list", err)
+		}
+
+		if N > len(pgns) {
+			return serrors.WrapStr("n is greater than number of PGNs in PLN list", err)
+		}
+
+		var randIs []int
+		for i := 0; i < N; i++ { //pick n pgns at random from pgns
+			r := rand.Intn(len(pgns))
+			if !contains(randIs, r) && !pgns[r].PGNIA.Equal(pgnmsgr.IA) {
+				randIs = append(randIs, r)
+			} else {
+				i--
+			}
+		}
+
+		var l []common.RawBytes
+		for _, dbEntry := range dbEntries {
+			l = append(l, *dbEntry.SignedBlob)
+		}
+		pgnList := pgn_mgmt.NewPGNList(l, uint64(time.Now().Unix()))
+		pld, err := pgn_mgmt.NewPld(1, pgnList)
+		if err != nil {
+			return serrors.WrapStr("Error forming pgn_mgmt Pld", err)
+		}
+		for _, i := range randIs {
+			pgn := pgns[i]
+			address := &snet.SVCAddr{IA: pgn.PGNIA, SVC: addr.SvcPGN}
+
+			pgncrypt := &pgncrypto.PGNSigner{}
+			err := pgncrypt.Init(ctx, pgnmsgr.Msgr, pgnmsgr.IA, pgncrypto.CfgDir)
+			if err != nil {
+				log.Error("error getting pgncrypto", err)
+				return err
+			}
+			signer, err := pgncrypt.SignerGen.Generate(context.Background())
+			if err != nil {
+				log.Error("error getting signer", err)
+				return err
+			}
+			pgnmsgr.Msgr.UpdateSigner(signer, []infra.MessageType{infra.PGNList})
+			err = pgnmsgr.Msgr.SendPGNRep(context.Background(), pld, address, rand.Uint64(), infra.PGNList)
+			if err != nil {
+				log.Error("Error sending pgn list", err)
+			}
+		}
+	}
+	return nil
+
+}
+
+func contains(l []int, elem int) bool {
+	for e := range l {
+		if e == elem {
+			return true
+		}
+	}
+	return false
+}

--- a/go/pgn/pgncomm/pgnhandler.go
+++ b/go/pgn/pgncomm/pgnhandler.go
@@ -1,0 +1,82 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgncomm
+
+import (
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/pgn/internal/pgncrypto"
+	"github.com/scionproto/scion/go/pgn/internal/pgnentryhelper"
+	"github.com/scionproto/scion/go/pgn/internal/pgnmsgr"
+	"github.com/scionproto/scion/go/pkg/trust"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type PGNEntryHandler struct {
+}
+
+func (n PGNEntryHandler) Handle(r *infra.Request) *infra.HandlerResult {
+	log.Info("Entering: PGNEntryHandler.Handle")
+	ctx := r.Context()
+	requester := r.Peer.(*snet.UDPAddr)
+
+	//Verify node list signature by pgn on the list
+	message := r.FullMessage.(*ctrl.SignedPld)
+	e := pgncrypto.PGNEngine{Msgr: pgnmsgr.Msgr, IA: pgnmsgr.IA}
+	verifier := trust.Verifier{BoundIA: requester.IA, Engine: e}
+	err := verifier.Verify(ctx, message.Blob, message.Sign)
+	rw, _ := infra.ResponseWriterFromContext(ctx)
+	sendAck := messenger.SendAckHelper(ctx, rw)
+	if err != nil {
+		log.Error("Certificate verification failed!", "Error: ", err)
+		sendAck(proto.Ack_ErrCode_reject, err.Error())
+		return nil
+	}
+
+	pld := &ctrl.Pld{}
+	err = proto.ParseFromRaw(pld, message.Blob)
+	if err != nil {
+		log.Error("Error decerializing control payload", "Error: ", err)
+		return nil
+	}
+
+	for _, l := range pld.Pgn.PGNList.L {
+		signedPGNEntry := &ctrl.SignedPld{}
+		err = proto.ParseFromRaw(signedPGNEntry, l)
+		if err != nil {
+			log.Error("Error getting signedPGNEntry", "Error: ", err)
+			continue
+		}
+		pld = &ctrl.Pld{}
+		proto.ParseFromRaw(pld, signedPGNEntry.Blob)
+		r := pld.Pgn.AddPGNEntryRequest
+		if err = pgnentryhelper.ValidatePGNEntry(r, signedPGNEntry, false); err != nil {
+			log.Error("Error validating signatures", "Error: ", err)
+			continue
+		}
+
+		//all verification done. Persist PGNEntry
+		e := pgncrypto.PGNEngine{Msgr: pgnmsgr.Msgr, IA: pgnmsgr.IA}
+		if err = pgnentryhelper.PersistEntry(r, e, l); err != nil {
+			log.Error("Error persisting PGNEntry ", "Error: ", err)
+			continue
+		}
+	}
+
+	return nil
+}

--- a/go/pkg/pgn/config/config.go
+++ b/go/pkg/pgn/config/config.go
@@ -28,11 +28,13 @@ import (
 )
 
 const (
-	DefaultDb = "./pgn.db"
+	DefaultDb      = "./pgn.db"
+	DefaultNumPGNs = 3
 )
 
 var (
-	DefaultConnectTimeout = duration{1 * time.Minute}
+	DefaultPropagateInterval = duration{1 * time.Hour} //1 hour
+	DefaultConnectTimeout    = duration{1 * time.Minute}
 )
 
 type Config struct {
@@ -105,6 +107,10 @@ type PGNConf struct {
 	//ConnectTimeout is the amount of time the messenger waits for a reply
 	//from the other service that it connects to. default (1 minute)
 	ConnectTimeout duration `toml:"connect_timeout,omitempty"`
+	//PropagateInterval is the time interval between PGNEntry lists propagations (default = 1 hour)
+	PropagateInterval duration `toml:"prop_interval"`
+	//NumPGNs is the number of PGNs that the PGNEntry list is propagated to in every interval (default = 3)
+	NumPGNs uint16 `toml:"num_pgns"`
 }
 
 func (cfg *PGNConf) InitDefaults() {
@@ -113,6 +119,12 @@ func (cfg *PGNConf) InitDefaults() {
 	}
 	if cfg.ConnectTimeout.Duration == 0 {
 		cfg.ConnectTimeout = DefaultConnectTimeout
+	}
+	if cfg.PropagateInterval.Duration == 0 {
+		cfg.PropagateInterval = DefaultPropagateInterval
+	}
+	if cfg.NumPGNs == 0 {
+		cfg.NumPGNs = DefaultNumPGNs
 	}
 }
 func (cfg *PGNConf) Validate() error {

--- a/go/pkg/pgn/config/configtest/configtest.go
+++ b/go/pkg/pgn/config/configtest/configtest.go
@@ -36,5 +36,6 @@ func CheckTestPGN(t *testing.T, cfg *config.PGNConf, id string) {
 	assert.Equal(t, "gen-certs/tls.key", cfg.KeyFile)
 	assert.Equal(t, xtest.MustParseIA("1-ff00:0:110"), cfg.PLNIA)
 	assert.Equal(t, config.DefaultConnectTimeout.Duration, cfg.ConnectTimeout.Duration)
-
+	assert.Equal(t, config.DefaultPropagateInterval.Duration, cfg.PropagateInterval.Duration)
+	assert.Equal(t, config.DefaultNumPGNs, int(cfg.NumPGNs))
 }

--- a/go/pkg/pgn/config/sample.go
+++ b/go/pkg/pgn/config/sample.go
@@ -40,4 +40,8 @@ pln_isd_as = "1-ff00:0:110"
 #ConnectTimeout is the amount of time the messenger waits for a reply
 #from the other service that it connects to. default (1 minute)
 connect_timeout = "1m"
+#PropagateInterval is the time interval between PGNEntry list propagations (default = 1 hour)
+prop_interval = "1h"
+#NumPGNs is the number of PGNs that the PGNEntry list is propagated to in every interval (default = 3)
+num_pgns = 3
 `

--- a/go/pkg/sciond/fetcher/fetcher.go
+++ b/go/pkg/sciond/fetcher/fetcher.go
@@ -113,8 +113,8 @@ func (f *fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 	switch {
 	case err == nil:
 		break
-	case errors.Is(err, segfetcher.ErrBadDst):
-		return &sciond.PathReply{ErrorCode: sciond.ErrorBadDstIA}, err
+	// case errors.Is(err, segfetcher.ErrBadDst):
+	// 	return &sciond.PathReply{ErrorCode: sciond.ErrorBadDstIA}, err
 	case errors.Is(err, segfetcher.ErrNoPaths):
 		return &sciond.PathReply{ErrorCode: sciond.ErrorNoPaths}, err
 	default:

--- a/proto/pgn.capnp
+++ b/proto/pgn.capnp
@@ -12,6 +12,7 @@ struct PGN {
         addPLNEntryRequest @2 :AddPLNEntryRequest;
         addPGNEntryRequest @3 :PGNEntry;
         pgnRep @4 :PGNRep;
+        pgnList @5 :PGNList;
     }
 }
 
@@ -20,7 +21,7 @@ struct AddPLNEntryRequest{
 }
 
 struct PGNList{
-    l @0 :List(PGNEntry);
+    l @0 :List(Data);
     timestamp @1 :UInt64; #timestamp for when the list was transmitted from a PGN
 }
 


### PR DESCRIPTION
This PR contains changes for PGN gossip
It contains the following changes:
- get PLN list in PGN. This is similar to a previous PR in which the MS pulls PLN List
- some refactoring of MS messages and new message types to define PGN lists and PGNEntries
- broadcast login in PGN based on config
- handler in PGN to handle lists it receives from other PGNs
- changes to SD, CS and PathDb to allow for wildcard in segment requests from https://github.com/marcfrei/scion/commit/8d688ed3c31d0abf8272795cf1194df4e6458309 and https://github.com/marcfrei/scion/commit/bb1a828206a8c344a270a6b6b06e952a604bb192
